### PR TITLE
Feature/repl input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .vscode/
+demo_files/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
+name = "clipboard-win"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7191c27c2357d9b7ef96baac1773290d4ca63b24205b82a3fd8a0637afcf0362"
+dependencies = [
+ "error-code",
+ "str-buf",
+ "winapi",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +285,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "errno"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,6 +309,27 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "error-code"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21"
+dependencies = [
+ "libc",
+ "str-buf",
+]
+
+[[package]]
+name = "fd-lock"
+version = "3.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef033ed5e9bad94e55838ca0ca906db0e043f517adda0c8b79c7a8c66c93c1b5"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -340,6 +378,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "is-terminal"
@@ -442,6 +489,26 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "nom"
@@ -625,6 +692,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,10 +835,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
+name = "rustyline"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "994eca4bca05c87e86e15d90fc7a91d1be64b4482b38cb2d27474568fe7c9db9"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "scopeguard",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "winapi",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -829,6 +935,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "smallvec"
+version = "1.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+
+[[package]]
 name = "sparesults"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -860,10 +972,17 @@ dependencies = [
  "oxigraph",
  "prettytable-rs",
  "regex",
+ "rustyline",
  "serde",
  "serde_derive",
  "serde_json",
 ]
+
+[[package]]
+name = "str-buf"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0"
 
 [[package]]
 name = "strsim"
@@ -924,6 +1043,12 @@ name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ serde = "*"
 serde_derive = "*"
 regex = "1.9.5"
 prettytable-rs = "^0.10"
+rustyline = "12.0.0"
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,14 +98,11 @@ fn print_query(store: &Store, query: &str, ns_dict: &mut Prefix) {
                     _ => continue
                 };
                 print_res.push(Cell::new(&let_return_value));
-<<<<<<< HEAD
-=======
             } else {
                 // This happens when there is no particular result for the variable, we need to set a place holder
                 // This allows the cell to be empty
                 print_res.push(Cell::new(""))
 
->>>>>>> main
             }
 
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,8 +93,6 @@ fn print_query(store: &Store, query: &str, ns_dict: &mut Prefix) {
                     _ => continue
                 };
                 print_res.push(Cell::new(&let_return_value));
-            } else {
-
             }
 
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ use prettytable::{ Table, Row, Cell };
 
 mod prefix;
 use crate::prefix::{Prefix, find_prefixes};
+mod repl;
+use crate::repl::readlinefn;
 
 
 #[derive(Parser, Debug)]
@@ -19,7 +21,7 @@ struct Args {
 
     /// name of the file or string for loading the query
     #[arg(short, long)]
-    query: String,
+    query: Option<String>,
 }
 
 
@@ -127,7 +129,16 @@ fn main() {
         return
     }
 
-    let query = args.query.clone();
+    let query = match args.query {
+        Some(str) => str,
+        None => {
+            let q = readlinefn();
+            match q {
+                Some(str) => str,
+                None => panic!("Error in readline")
+            }
+        },
+    };
 
     if std::path::Path::new(&query).exists()  {
         let read_file = fs::read_to_string(&query);

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,0 +1,5 @@
+use rustyline::error::ReadlineError;
+use rustyline::{DefaultEditor, Result};
+
+
+

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,11 +1,9 @@
 // use rustyline::error::ReadlineError;
-use crate::prefix::{Prefix, find_prefixes};
-
+use crate::prefix::Prefix;
 
 use rustyline::highlight::MatchingBracketHighlighter;
 use rustyline::validate::MatchingBracketValidator;
-use rustyline::{Editor};
-use rustyline::{Completer, Helper, Highlighter, Hinter, Validator};
+use rustyline::{Editor, Completer, Helper, Highlighter, Hinter, Validator};
 
 #[derive(Completer, Helper, Highlighter, Hinter, Validator)]
 struct InputValidator {

--- a/src/repl.rs
+++ b/src/repl.rs
@@ -1,5 +1,30 @@
-use rustyline::error::ReadlineError;
-use rustyline::{DefaultEditor, Result};
+// use rustyline::error::ReadlineError;
+use rustyline::DefaultEditor;
 
+
+///
+/// Read the function from the command line
+/// This function reads a sparql file from a command prompt
+/// TODO: Update the rl editor to handle syntax highlighting and multi line commands
+pub fn readlinefn() -> Option<String> {
+  let new_editor = DefaultEditor::new();
+  let mut rl = match new_editor {
+    Ok(editor) => editor,
+    Err(_) => {
+      println!("Error in File Reader");
+      return None;
+    }
+  };
+
+  let readline = rl.readline("");
+  match readline {
+    Ok(line) => return Some(line),
+    Err(_) => {
+      println!("Error in Reading the Line");
+      return None
+    }
+  }
+
+}
 
 


### PR DESCRIPTION
Initial implementation for a multi-line repl. 

This currently has several limitations:
1. You have to write the query like this: `select ?s ?p ?o {` with a final bracket. Once the brackets match, the script will execute. so you will need to inline any `limit` or group by clauses. 
2. there is no indentation or syntax highlighting yet
3. there is a bug where the new line between prefix declaration and the select statement will get removed if you press the back space button. 

But it currently will allow for some multi line editing and will inject the prefixes as defined in the rdf files at the beginning of the query. 